### PR TITLE
Updates first user story - applicant show page with more attributes

### DIFF
--- a/app/models/applicant.rb
+++ b/app/models/applicant.rb
@@ -1,6 +1,9 @@
 class Applicant < ApplicationRecord 
     validates :name, presence: true
     validates :address, presence: true
+    validates :city, presence: true
+    validates :state, presence: true
+    validates :zip, presence: true, numericality: true
     validates :description, presence: true
     validates :names_pets_wanted, presence: true
     validates :application_status, presence: true

--- a/app/views/applicants/show.html.erb
+++ b/app/views/applicants/show.html.erb
@@ -1,5 +1,8 @@
 <h1>name: <%= @applicant.name %></h1>
 <h3>address: <%= @applicant.address %></h3>
+<h3>address: <%= @applicant.city %></h3>
+<h3>address: <%= @applicant.state %></h3>
+<h3>address: <%= @applicant.zip %></h3>
 
 <h3>name of pets wanting to adopt: <%= pets.each do |pet| %>
 <%= link_to "#{pet.name}", "/pets/#{pet.id}" %>

--- a/db/migrate/20220715002605_add_details_to_applicants.rb
+++ b/db/migrate/20220715002605_add_details_to_applicants.rb
@@ -1,0 +1,7 @@
+class AddDetailsToApplicants < ActiveRecord::Migration[5.2]
+  def change
+    add_column :applicants, :city, :string
+    add_column :applicants, :state, :string
+    add_column :applicants, :zip, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_07_14_203820) do
+ActiveRecord::Schema.define(version: 2022_07_15_002605) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -23,6 +23,9 @@ ActiveRecord::Schema.define(version: 2022_07_14_203820) do
     t.string "application_status"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "city"
+    t.string "state"
+    t.integer "zip"
   end
 
   create_table "pets", force: :cascade do |t|

--- a/spec/features/applications/show_spec.rb
+++ b/spec/features/applications/show_spec.rb
@@ -8,11 +8,13 @@ RSpec.describe "application show page" do
 #     names of all pets that this application is for (all names of pets should be links to their show page)
 #     The Application's status, either "In Progress", "Pending", "Accepted", or "Rejected"
     it 'displays the name, full address, description, names of all pets in the application as links, and the status of the application' do 
-        new_applicant = Applicant.create!(name: "Test", address: "5555 Test Avenue, City, State, 55555", names_pets_wanted: "Fido", description: "they love pets!", application_status: "In Progress")
+        new_applicant = Applicant.create!(name: "Test", address: "5555 Test Avenue", city: "Denver", state: "CO", zip: 55555, names_pets_wanted: "Fido", description: "they love pets!", application_status: "In Progress")
         visit "/applications/#{new_applicant.id}"
         # save_and_open_page
         expect(page).to have_content("name: Test")
-        expect(page).to have_content("address: 5555 Test Avenue, City, State, 55555")
+        expect(page).to have_content("address: 5555 Test Avenue")
+        expect(page).to have_content("city: Denver")
+        expect(page).to have_content("state: CO")
         expect(page).to have_content("name of pets wanting to adopt: Fido")
         #Links to pets not currently working atm - Nick
         

--- a/spec/models/applicant_spec.rb
+++ b/spec/models/applicant_spec.rb
@@ -4,6 +4,9 @@ RSpec.describe Applicant, type: :model do
     describe 'validations' do
         it { should validate_presence_of(:name) }
         it { should validate_presence_of(:address) }
+        it { should validate_presence_of(:city) }
+        it { should validate_presence_of(:state) }
+        it { should validate_presence_of(:zip) }
         it { should validate_presence_of(:names_pets_wanted) }
         it { should validate_presence_of(:description) }
         it { should validate_presence_of(:application_status) }


### PR DESCRIPTION
Looking at future user stories I think we will need to have the applicant show page address attributes be separated out into `address, city, state, zip` rather than a single string of an address, so I added a new migration to update the Applicants table

updated the model to show those updated validations

Updated the html applicant show page to show each of those attributes

Updated the model/feature specs to test for the added validations/attributes

-GJ